### PR TITLE
remove fmt import

### DIFF
--- a/sevensegment.go
+++ b/sevensegment.go
@@ -1,8 +1,7 @@
 package sevensegment
 
 import (
-	"fmt"
-	"log"
+  "log"
   "periph.io/x/periph/conn/i2c"
   "periph.io/x/periph/conn/physic"
   "periph.io/x/periph/host"

--- a/sevensegment.go
+++ b/sevensegment.go
@@ -1,11 +1,11 @@
 package sevensegment
 
 import (
-  "log"
-  "periph.io/x/periph/conn/i2c"
-  "periph.io/x/periph/conn/physic"
-  "periph.io/x/periph/host"
-  "periph.io/x/periph/conn/i2c/i2creg"
+	"log"
+	"periph.io/x/periph/conn/i2c"
+	"periph.io/x/periph/conn/i2c/i2creg"
+	"periph.io/x/periph/conn/physic"
+	"periph.io/x/periph/host"
 )
 
 // Sevensegment with a buffer to hold desired


### PR DESCRIPTION
sevensegment.go:4:2: imported and not used: "fmt"