### PR TITLE
remove SetSpeed()

### DIFF
--- a/sevensegment.go
+++ b/sevensegment.go
@@ -2,9 +2,9 @@ package sevensegment
 
 import (
 	"log"
+
 	"periph.io/x/periph/conn/i2c"
 	"periph.io/x/periph/conn/i2c/i2creg"
-	"periph.io/x/periph/conn/physic"
 	"periph.io/x/periph/host"
 )
 
@@ -22,10 +22,6 @@ func NewSevenSegment(addr byte) (ss *SevenSegment) {
 		log.Fatal(err)
 		return
 	} else {
-		if b.SetSpeed(100 * physic.KiloHertz); err != nil {
-			log.Fatal(err)
-			return
-		}
 		ss.d = &i2c.Dev{Addr: uint16(addr), Bus: b}
 		ss.OscillatorOn()
 		ss.DisplayOn()


### PR DESCRIPTION
According to https://github.com/rafalop/sevensegment/issues/6 this never works and always returns an error, tested on 3 different RPI models. After removal of `SetSpeed()` everything works as intended.