### PR TITLE
Use the new periph.io package paths

### DIFF
--- a/sevensegment.go
+++ b/sevensegment.go
@@ -3,9 +3,9 @@ package sevensegment
 import (
 	"log"
 
-	"periph.io/x/periph/conn/i2c"
-	"periph.io/x/periph/conn/i2c/i2creg"
-	"periph.io/x/periph/host"
+	"periph.io/x/conn/v3/i2c"
+	"periph.io/x/conn/v3/i2c/i2creg"
+	"periph.io/x/host/v3"
 )
 
 // Sevensegment with a buffer to hold desired


### PR DESCRIPTION
- the periph project has removed the code from its previous repo, so the existing package paths no longer work
- following the instructions at https://periph.io/news/2022/removal/ the new package paths were selected.
- this was validated on a Raspberry Pi Model B and things still work, unfortunately I don't have other devices to confirm this change on